### PR TITLE
Update VolumeBar's properties on subsequent calls

### DIFF
--- a/src/ios/VolumeSlider.m
+++ b/src/ios/VolumeSlider.m
@@ -41,10 +41,6 @@
 		return;
 	}
 
-	if (self.mpVolumeViewParentView != NULL) {
-			return; //already created, don't need to create it again
-	}
-
 	CGFloat originx,originy,width;
 	CGFloat height = 30;
 
@@ -65,6 +61,23 @@
 								 height
 								 );
 
+	
+	if (self.mpVolumeViewParentView != NULL) { // update current instance
+		[self.mpVolumeViewParentView setFrame:viewRect];
+		[self.myVolumeView setFrame:self.mpVolumeViewParentView.bounds];
+		if([color isEqual: @"white"]){
+			[self.myVolumeView setRouteButtonImage:[UIImage imageNamed:@"icon-airplaywhite"] forState:UIControlStateNormal];
+			[self.myVolumeView setRouteButtonImage:[UIImage imageNamed:@"icon-airplayprimary"] forState:UIControlStateHighlighted];
+			[self.myVolumeView setRouteButtonImage:[UIImage imageNamed:@"icon-airplayprimary"] forState:UIControlStateSelected];
+		}
+		if([color isEqual: @"black"]){
+			[self.myVolumeView setRouteButtonImage:[UIImage imageNamed:@"icon-airplay"] forState:UIControlStateNormal];
+			[self.myVolumeView setRouteButtonImage:[UIImage imageNamed:@"icon-airplayprimary"] forState:UIControlStateHighlighted];
+			[self.myVolumeView setRouteButtonImage:[UIImage imageNamed:@"icon-airplayprimary"] forState:UIControlStateSelected];
+		}
+		return; //already created, don't need to create it again
+	}
+	
 	self.mpVolumeViewParentView = [[UIView alloc] initWithFrame:viewRect];
 
 	[self.webView.superview addSubview:mpVolumeViewParentView];


### PR DESCRIPTION
Modified the 'createVolumeSlider' method so that you can change the properties of the Volumebar.
This will help you rearrange the bar to a new position (or size) on multiple views of the app.
Instead of quick returning when self.mpVolumeViewParentView is not null it updates the properties and then returns.
I created this to meet the requirements for one of my apps. Allready tested it and it works.